### PR TITLE
In dev mode, emit ESLint errors as warnings

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -139,6 +139,7 @@ module.exports = {
               // @remove-on-eject-begin
               ignore: false,
               configFile: require.resolve(paths.appPath + '/.eslintrc.js'),
+              emitWarning: true,
               // @remove-on-eject-end
             },
             loader: require.resolve('eslint-loader'),


### PR DESCRIPTION
Regular `create-react-app` has an ESLint config that only ever shows warnings. When we applied the unmodified AirBnB config to the starter app (which only ever shows errors), we created an unintended behavior wherein _anything_ that's even a little bit wrong with our code will cause the app to not render (for example, importing a module and not using it yet because we want to see how some other change looks first).

This commit effectively forces the same kind of behavior that the "normal" `create-react-app` has, although it only does that in the dev environment.