### PR TITLE
Reflect CSS Modules classnames in snapshots

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -47,6 +47,7 @@
     "file-loader": "0.11.1",
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.28.0",
+    "identity-obj-proxy": "3.0.0",
     "jest": "20.0.3",
     "node-sass": "^4.5.3",
     "object-assign": "4.1.1",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -40,6 +40,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
+      "^.+\\.s?css$": "identity-obj-proxy",
     },
     "moduleDirectories": [
       "node_modules",


### PR DESCRIPTION
Mock (S)CSS file imports in such a way that when they're asked for some property, they return that same property name.

This way,
```
<Foo className={styles.bar} />
```
becomes
```
<Foo className="bar" />
```
in a snapshot!

---

This technique/library is based directly on the suggestion in [Jest docs](https://facebook.github.io/jest/docs/webpack.html#mocking-css-modules). Without it, a lot of the snapshots are useless as they always render either `className="undefined"` or `className=""` (I don't know why it's one sometimes and the other other times).

Unfortunately, I currently don't know of a way to test this, other than by modifying my local `node_modules`. I tried creating a new app using a script from my fork of the repo but I cannot do that because of the way the repo is structured — it lacks a package name and cannot be installed directly with yarn/npm. I believe only the `packages/react-scripts` part gets published on npm? Please tell me if there is some convenient-ish way for me to test this, otherwise I may have to resort to publishing my fork as its own package...