### PR TITLE
Add z-index variables to SCSS template

### DIFF
--- a/packages/react-scripts/template/src/shared/styles/index.scss
+++ b/packages/react-scripts/template/src/shared/styles/index.scss
@@ -1,3 +1,4 @@
+@import './z-index.scss';
 @import './colors.scss';
 @import './typography.scss';
 @import './mixins.scss';

--- a/packages/react-scripts/template/src/shared/styles/z-index.scss
+++ b/packages/react-scripts/template/src/shared/styles/z-index.scss
@@ -1,0 +1,9 @@
+$z-index-1: 1000;
+$z-index-2: 2000;
+$z-index-3: 3000;
+$z-index-4: 4000;
+$z-index-5: 5000;
+$z-index-6: 6000;
+$z-index-7: 7000;
+$z-index-8: 8000;
+$z-index-9: 9000;


### PR DESCRIPTION
Style linter will complain when one uses a `z-index` CSS property without a variable — but the variables are not currently included in the template! This PR adds those variables.