### PR TITLE
Simplify lint commands

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -43,8 +43,8 @@ module.exports = function(
     build: 'react-scripts build',
     test: 'react-scripts test --env=jsdom',
     eject: 'react-scripts eject',
-    stylelint: 'node ./node_modules/stylelint/bin/stylelint.js src/**/*.scss',
-    eslint: 'node ./node_modules/eslint/bin/eslint.js src/**/*.js',
+    stylelint: 'stylelint src/**/*.scss',
+    eslint: 'eslint src/**/*.js',
   };
 
   fs.writeFileSync(


### PR DESCRIPTION
Since commands in npm scripts use local packages by default, it's not necessary to specify path to local `node_modules/`. This PR changes npm scripts: `eslint` and `stylelint` to take advantage of that fact.
