### PR TITLE
Apply sass-loader first, before postcss-loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -205,9 +205,6 @@ module.exports = {
                 },
               },
               {
-                loader: require.resolve('sass-loader'),
-              },
-              {
                 loader: require.resolve('postcss-loader'),
                 options: {
                   // Necessary for external CSS imports to work
@@ -226,6 +223,9 @@ module.exports = {
                     }),
                   ],
                 },
+              {
+                loader: require.resolve('sass-loader'),
+              },
               },
             ],
           },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -207,12 +207,6 @@ module.exports = {
                       },
                     },
                     {
-                      loader: require.resolve('sass-loader'),
-                      options: {
-                        sourceMap: true,
-                      },
-                    },
-                    {
                       loader: require.resolve('postcss-loader'),
                       options: {
                         // Necessary for external CSS imports to work
@@ -230,6 +224,12 @@ module.exports = {
                             flexbox: 'no-2009',
                           }),
                         ],
+                      },
+                    },
+                    {
+                      loader: require.resolve('sass-loader'),
+                      options: {
+                        sourceMap: true,
                       },
                     },
                   ],


### PR DESCRIPTION
There is currently an issue with at least one part of the SCSS syntax, namely string interpolation in media queries. For example:
```
Module build failed: Syntax Error 

(4:12) Unknown word

  2 | 
  3 | .test {
> 4 |   @media #{$test} {
    |            ^
  5 |     color: red;
  6 |   }
```
Where `$test` could even just be a string, like `#{'screen and (min-width: 768px)'}`.

Presumably, the issue also affects some other parts of the syntax, however for now this is the only thing I've caught.

The reason for this problem seems to be the order of CSS transformations applied by Webpack. Since `postcss-loader` is applied first, it hangs up on the unknown syntax before `sass-loader` manages to process it.

This PR changes the order of loaders for CSS/SCSS code, so that `sass-loader` gets applied before any others.