### PR TITLE
Do not add --watch option to test script automatically

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -28,11 +28,6 @@ require('../config/env');
 const jest = require('jest');
 const argv = process.argv.slice(2);
 
-// Watch unless on CI or in coverage mode
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
-  argv.push('--watch');
-}
-
 // @remove-on-eject-begin
 // This is not necessary after eject because we embed config into package.json.
 const createJestConfig = require('./utils/createJestConfig');


### PR DESCRIPTION
`create-react-app` adds `--watch` options to `yarn test` script automatically, unless running in CI env or `--coverage` option being present. This is cool, until one wants to use it as **git hook**. It may be done, using options above, but setting env to CI is a hack and `--coverage` obfuscates results with long table of files. I propose to disable this behaviour, which is exactly what this PR is doing. 

The only downside of this change is necessity to add `test:watch` script (which I would add myself, if only I knew how to do it).