### PR TITLE
Fix linters not working because of globbing issue with bash

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -43,8 +43,8 @@ module.exports = function(
     build: 'react-scripts build',
     test: 'react-scripts test --env=jsdom',
     eject: 'react-scripts eject',
-    stylelint: 'stylelint src/**/*.scss',
-    eslint: 'eslint src/**/*.js',
+    stylelint: 'stylelint "src/**/*.scss"',
+    eslint: 'eslint "src/**/*.js"',
   };
 
   fs.writeFileSync(


### PR DESCRIPTION
Linter scripts didn't work sometimes (returning false negatives), presumably (?) because of an issue where globbing doesn't quite work as expected in bash. Adding quotes around the path for these scripts fixes the issue.

(By way of explanation, the issue to me seems to lie in the inability of bash to handle the double wildcard operator `**` by default. This is handled with no problems by the zsh shell (but I guess yarn runs the scripts in a bash environment). It is also supported since bash 4.0 as an optional feature but it [requires being explicitly set](http://www.linuxjournal.com/content/globstar-new-bash-globbing-option).)