### PR TITLE
Change the license to MIT

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "description": "Netguru configuration and scripts for Create React App",
   "repository": "netguru/create-react-app",
-  "license": "BSD-3-Clause",
+  "license": "MIT",
   "engines": {
     "node": ">=6"
   },


### PR DESCRIPTION
Changes the license of our package to MIT, to follow the recent decision at Facebook. 
