### PR TITLE
Change react-hot-loader version from next (v.4 beta) to v.3

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-hot-loader": "next",
+    "react-hot-loader": "^3.1.3",
     "normalize.css": "^7.0.0"
   },
   "optionalDependencies": {

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -101,7 +101,7 @@ module.exports = function(
     command = 'npm';
     args = ['install', '--save', verbose && '--verbose'].filter(e => e);
   }
-  args.push('react', 'react-dom', 'react-hot-loader@next', 'normalize.css');
+  args.push('react', 'react-dom', 'react-hot-loader@^3.1.3', 'normalize.css');
 
   // Install additional template dependencies, if present
   const templateDependenciesPath = path.join(


### PR DESCRIPTION
Should fix #27.

We can upgrade `react-hot-loader`, and make sure it works, when it leaves beta.
