### PR TITLE
Bump to v.2.0.0

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netguru-react-scripts",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0",
   "description": "Netguru configuration and scripts for Create React App",
   "repository": "netguru/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netguru-react-scripts",
-  "version": "1.3.0",
+  "version": "2.0.0-beta.6",
   "description": "Netguru configuration and scripts for Create React App",
   "repository": "netguru/create-react-app",
   "license": "MIT",


### PR DESCRIPTION
This PR will increment the major version ~but for now it's in beta~.

Noteworthy changes (also, breaking):
 - stuff from upstream as mentioned in #22,
 - updates to linters (#24, #25) — _will_ break your app,
 - when you import markdown files, you get their text (unparsed, though), not the reference to the file (#29, #34).
 - SVG files named according to a pattern `<name>.inline.svg` are imported as React components rather than images (#38).
 - Node.js constants can no longer be imported unless a flag is used (#39).