### PR TITLE
Disable loading `constants` module

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -298,6 +298,7 @@ module.exports = {
     net: 'empty',
     tls: 'empty',
     child_process: 'empty',
+    constants: false,
   },
   // Turn off performance hints during development because we don't do any
   // splitting or minification in interest of speed. These warnings become

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -298,7 +298,7 @@ module.exports = {
     net: 'empty',
     tls: 'empty',
     child_process: 'empty',
-    constants: false,
+    constants: process.env.USE_NODE_CONSTANTS === 'true',
   },
   // Turn off performance hints during development because we don't do any
   // splitting or minification in interest of speed. These warnings become

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -384,5 +384,6 @@ module.exports = {
     net: 'empty',
     tls: 'empty',
     child_process: 'empty',
+    constants: false,
   },
 };

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -384,6 +384,6 @@ module.exports = {
     net: 'empty',
     tls: 'empty',
     child_process: 'empty',
-    constants: false,
+    constants: process.env.USE_NODE_CONSTANTS === 'true',
   },
 };


### PR DESCRIPTION
This PR lets you implicitly import `index.js` file inside `constants` directory, where before a node module would load with native constants.

Before:
```js
import { TEST_CONSTANT } from 'constants/index';
```

After:
```js
import { TEST_CONSTANT } from 'constants';
```