### PR TITLE
Removes the source PostCSS warnings on discarding the source maps

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -236,9 +236,6 @@ module.exports = {
                     },
                     {
                       loader: require.resolve('sass-loader'),
-                      options: {
-                        sourceMap: true,
-                      },
                     },
                   ],
                 },


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The problem that is solved here is the following:
1. When `options.sourceMap == false` is set for `postcss-loader`, there is a warning about discarding source maps from `sass-loader`.
1. CircleCI has `CI=true`, which makes build scripts treat warnings as errors and those PostCSS warnings break the build.
1. The current config discards the source maps in any case so I disabled generating them in the first place.